### PR TITLE
Fix build errors on 32-bit systems

### DIFF
--- a/libssh2/src/Network/SSH/Client/LibSSH2/Errors.chs
+++ b/libssh2/src/Network/SSH/Client/LibSSH2/Errors.chs
@@ -111,6 +111,9 @@ instance IntResult (Int, a, b) where
 instance IntResult (Int, a, b, c) where
   intResult = \(i, _, _, _) -> i
 
+instance IntResult CInt where
+  intResult = fromIntegral
+
 instance IntResult CLong where
   intResult = fromIntegral
 

--- a/libssh2/src/Network/SSH/Client/LibSSH2/Foreign.chs
+++ b/libssh2/src/Network/SSH/Client/LibSSH2/Foreign.chs
@@ -291,11 +291,7 @@ writeChannel ch bs =
                            $ {# call channel_write_ex #} (toPointer ch) 
                                                          0 
                                                          (cstr `plusPtr` offset) 
-#ifdef mingw32_HOST_OS
                                                          (fromIntegral len)
-#else
-                                                         len
-#endif
       if fromIntegral written < len 
         then go (offset + fromIntegral written) (len - fromIntegral written) cstr
         else return ()
@@ -364,7 +360,7 @@ writeChannelFromHandle ch h =
                   0
                   (plusPtr buffer written)
                   (fromIntegral size)
-      send (written + fromIntegral sent) (size - sent) buffer
+      send (written + fromIntegral sent) (size - fromIntegral sent) buffer
 
     bufferSize = 0x100000
 


### PR DESCRIPTION
Hi Ilya,

libssh2 failed to build on 32-bit platforms. Unfortunately, that included Hackage, which meant Hackage lists libssh2 as having a build failure; and consequently packages that rely on libssh2 (such as the Azure Cloud Haskell backend) fail to build on Hackage too. This patch fixes the issue; I'd appreciate it if you could apply it and release this to Hackage as 0.2.0.1 (I haven't updated the .cabal file).

Also, we should probably specify a minimum version of the C library, but that's less urgent. I'll open an issue for it.

Thanks!

Edsko
