### PR TITLE
issue #7 fix

### DIFF
--- a/libssh2/include/gcrypt-fix.h
+++ b/libssh2/include/gcrypt-fix.h
@@ -1,0 +1,6 @@
+#ifndef GCRYPT_FIX_H
+#define GCRYPT_FIX_H
+
+void gcrypt_fix();
+
+#endif

--- a/libssh2/libssh2.cabal
+++ b/libssh2/libssh2.cabal
@@ -42,6 +42,10 @@ Extra-source-files:  ssh-client.hs, Makefile, include/libssh2_local.h
 -- Constraint on the version of Cabal needed to build this package.
 Cabal-version:       >=1.8
 
+flag gcrypt
+  description: add hack that allows to run threaded program when libssh2 is built against gcrypt
+  default: False
+
 flag example-client
   description: Build the example client
   default: False
@@ -68,6 +72,12 @@ Library
   
   Build-tools:         c2hs
   HS-Source-Dirs:      src
+
+  if flag(gcrypt)
+      c-sources:           src/Network/SSH/Client/LibSSH2/FFI/gcrypt-fix.c
+      Includes:            gcrypt-fix.h
+      Exposed-modules:     Network.SSH.Client.LibSSH2.GCrypt
+      Cpp-options:         -DGCRYPT
   
 Executable hs-ssh-client
   if flag(example-client)

--- a/libssh2/src/Network/SSH/Client/LibSSH2/FFI/gcrypt-fix.c
+++ b/libssh2/src/Network/SSH/Client/LibSSH2/FFI/gcrypt-fix.c
@@ -1,0 +1,11 @@
+#include <gcrypt.h>
+#include <pthread.h>
+#include <error.h>
+#include <errno.h>
+#include "gcrypt-fix.h"
+
+GCRY_THREAD_OPTION_PTHREAD_IMPL;
+
+void gcrypt_fix() {
+   gcry_control (GCRYCTL_SET_THREAD_CBS, &gcry_threads_pthread);
+}

--- a/libssh2/src/Network/SSH/Client/LibSSH2/Foreign.chs
+++ b/libssh2/src/Network/SSH/Client/LibSSH2/Foreign.chs
@@ -47,6 +47,9 @@ import qualified Data.ByteString.Unsafe as BSS
 
 import Network.SSH.Client.LibSSH2.Types
 import Network.SSH.Client.LibSSH2.Errors
+#ifdef GCRYPT
+import Network.SSH.Client.LibSSH2.GCrypt
+#endif
 
 -- Known host flags. See libssh2 documentation.
 data KnownHostType =
@@ -123,7 +126,11 @@ ssh2socket (MkSocket s _ _ _ _) =
 -- | Initialize libssh2. Pass True to enable encryption
 -- or False to disable it.
 initialize :: Bool -> IO ()
+#ifdef GCRYPT
+initialize flags = void . handleInt Nothing $ gcryptFix >> initialize_ flags
+#else
 initialize flags = void . handleInt Nothing $ initialize_ flags
+#endif
 
 -- | Deinitialize libssh2.
 #ifdef mingw32_HOST_OS

--- a/libssh2/src/Network/SSH/Client/LibSSH2/GCrypt.hs
+++ b/libssh2/src/Network/SSH/Client/LibSSH2/GCrypt.hs
@@ -1,0 +1,7 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+module Network.SSH.Client.LibSSH2.GCrypt 
+  ( gcryptFix )
+  where
+
+foreign import ccall "gcrypt_fix" gcryptFix :: IO ()
+


### PR DESCRIPTION
This fix setups gcrypt to use pthread api to set mutexes otherwise
it's impossible to run ssh2 in a threaded runtime

see issue #7: https://github.com/portnov/libssh2-hs/issues/7
