### PR TITLE
added missing constructor for error code of (-46)

### DIFF
--- a/libssh2/src/Network/SSH/Client/LibSSH2/Errors.chs
+++ b/libssh2/src/Network/SSH/Client/LibSSH2/Errors.chs
@@ -79,6 +79,7 @@ data ErrorCode =
   | SOCKET_RECV
   | ENCRYPT
   | BAD_SOCKET
+  | ERROR_KNOWN_HOSTS
   deriving (Eq, Show, Ord, Enum, Data, Typeable)
 
 instance Exception ErrorCode


### PR DESCRIPTION
hey, your ErrorCode type doesn't seem to support (-46) return value. Whenever my known_hosts is messed up and I try to use your lib, I get this exception
**\* Exception: toEnum{ErrorCode}: tag (46) is outside of enumeration's range (0,45)

Would you mind fixing it? Thanks.
