### PR TITLE
Fix issue with shell open.

### DIFF
--- a/libssh2/src/Network/SSH/Client/LibSSH2/Foreign.chs
+++ b/libssh2/src/Network/SSH/Client/LibSSH2/Foreign.chs
@@ -282,7 +282,10 @@ channelExecute c command = channelProcess c "exec" command
 
 -- | Execute shell command
 channelShell :: Channel -> IO () 
-channelShell c = void . handleInt (Just $ channelSession c) $ channelProcessStartup_ c "shell" ""  
+channelShell c = void . handleInt (Just $ channelSession c) $ do
+  withCStringLen "shell" $ \(s,l) -> do
+    res <- channelProcessStartup_'_ (toPointer c) s (fromIntegral l) nullPtr 0
+    return $ (res :: CInt)
 
 {# fun channel_request_pty_ex as requestPTYEx
   { toPointer `Channel',


### PR DESCRIPTION
channelShell function passed additional data and have not
pass integrity check my modern openssh servers.
This patch fixes this issue.

X-GitHub-Issue-No: #23
X-GitHub-Url: https://github.com/portnov/libssh2-hs/issues/23