### PR TITLE
Conduit interface to `directTcpIpEx`

### DIFF
--- a/libssh2-conduit/Network/SSH/Client/LibSSH2/Conduit.hs
+++ b/libssh2-conduit/Network/SSH/Client/LibSSH2/Conduit.hs
@@ -17,7 +17,7 @@ import qualified Data.ByteString as B
 import Network.SSH.Client.LibSSH2.Foreign
 import Network.SSH.Client.LibSSH2
 
--- | Read all contents of libssh2's Channel.
+-- | Stream data from @Channel@.
 sourceChannel :: MonadIO m => Channel -> Source m B.ByteString
 sourceChannel ch = src
   where

--- a/libssh2/src/Network/SSH/Client/LibSSH2.hs
+++ b/libssh2/src/Network/SSH/Client/LibSSH2.hs
@@ -17,6 +17,7 @@ module Network.SSH.Client.LibSSH2
    scpReceiveFile,
    runShellCommands,
    execCommands,
+   directTcpIpEx,
 
    -- * Sftp Functions
    withSFTP,

--- a/libssh2/src/Network/SSH/Client/LibSSH2/Foreign.chs
+++ b/libssh2/src/Network/SSH/Client/LibSSH2/Foreign.chs
@@ -37,6 +37,7 @@ module Network.SSH.Client.LibSSH2.Foreign
    writeChannelFromHandle, readChannelToHandle,
    channelProcess, channelExecute, channelShell,
    requestPTY, requestPTYEx,
+   directTcpIpEx,
    channelExitStatus, channelExitSignal,
    scpSendChannel, scpReceiveChannel, pollChannelRead,
 
@@ -279,6 +280,16 @@ usernamePasswordAuth session username password =
    `String' &,
    `Int', `Int',
    `String' & } -> `Ptr ()' id #}
+
+{# fun channel_direct_tcpip_ex as directTcpIpEx_
+  { toPointer `Session',
+   `String',
+   `Int',
+   `String',
+   `Int' } -> `Ptr ()' id #}
+
+directTcpIpEx :: Session -> String -> Int -> String -> Int -> IO Channel
+directTcpIpEx s host port shost sport = handleNullPtr (Just s) (channelFromPointer s) $ directTcpIpEx_ s host port shost sport
 
 -- | Open a channel for session.
 openChannelSession :: Session -> IO Channel


### PR DESCRIPTION
Here's a minimal if low-level-ish client demonstrating usage. It works like `ssh -L 3000:4000 locallhost`.
```haskell
{-# LANGUAGE OverloadedStrings #-}

module Main where

import Conduit
import Control.Concurrent
import Control.Concurrent.Async (concurrently)
import Control.Monad
import Data.Conduit.Network

import Network.SSH.Client.LibSSH2.Foreign
import Network.SSH.Client.LibSSH2.Conduit
import Network.SSH.Client.LibSSH2

import Network.Socket hiding (send, sendTo, recv, recvFrom)

import qualified Control.Exception as E

main :: IO ()
main = do
  initialize True

  E.bracket open (\s -> close s >> exit) $ \sock -> void . forever $ do
    (conn, _) <- accept sock
    forkFinally
      (handleConn conn)
      (const $ close conn)

open :: IO Socket
open = do
  sock <- socket AF_INET6 Stream defaultProtocol
  setSocketOption sock ReuseAddr 1
  setSocketOption sock ReusePort 1
  bind sock $ SockAddrInet6 3000 0 iN6ADDR_ANY 0
  listen sock 5
  return sock

handleConn :: Socket -> IO ()
handleConn conn = withSession "localhost" 22 $ \session -> do
  usernamePasswordAuth session "test" "test"
  channel <- directTcpIpEx session "localhost" 4000 "localhost" 22

  void $ concurrently
      (runConduit $ sourceChannel channel .| sinkSocket conn)
      (runConduit $ sourceSocket conn .| sinkChannel channel)

  closeChannel channel
  freeChannel channel
```

Should this be adapted to using `CommandsHandle`?