### PR TITLE
Added libssh2 dependency on network < 3.0 and ignored locations to support cabal builds.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ ssh-client
 libssh2/.ghc.environment.*
 libssh2/dist
 libssh2/dist-*
+libssh2-conduit/.ghc.environment.*
+libssh2-conduit/dist
+libssh2-conduit/dist-*

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ libssh2/Network/SSH/Client/LibSSH2/Types.hs
 libssh2/Network/SSH/Client/LibSSH2/Errors.hs
 ssh-client
 .stack-work/
+libssh2/.ghc.environment.*
+libssh2/dist
+libssh2/dist-*

--- a/libssh2/libssh2.cabal
+++ b/libssh2/libssh2.cabal
@@ -60,7 +60,8 @@ Library
   Include-dirs:        include
   Includes:            include/libssh2_local.h
 
-  Build-depends:       base >= 4 && < 5, network >= 2.3,
+  Build-depends:       base >= 4 && < 5,
+                       network >= 2.3 && < 3.0, -- libssh2 uses deprecated thigs not available in v3.0
                        syb >= 0.3.3, time >= 1.2,
                        bytestring >= 0.9,
                        unix

--- a/libssh2/libssh2.cabal
+++ b/libssh2/libssh2.cabal
@@ -61,7 +61,7 @@ Library
   Includes:            include/libssh2_local.h
 
   Build-depends:       base >= 4 && < 5,
-                       network >= 2.3 && < 3.0, -- libssh2 uses deprecated thigs not available in v3.0
+                       network >= 2.3 && < 3.0,
                        syb >= 0.3.3, time >= 1.2,
                        bytestring >= 0.9,
                        unix


### PR DESCRIPTION
libssh2 uses things deprecated in network v3. I have added that dependency in the cabal file. Also added a few locations to .gitignore to be friendly with cabal builds.