### PR TITLE
int2dir: recognise 0 as valid value

### DIFF
--- a/libssh2/src/Network/SSH/Client/LibSSH2/Errors.chs
+++ b/libssh2/src/Network/SSH/Client/LibSSH2/Errors.chs
@@ -190,9 +190,12 @@ threadWaitSession (Just ctx) = do
     Nothing -> error "EAGAIN thrown on session without socket"
     Just socket -> do
       dirs <- blockedDirections s
-      if (OUTBOUND `elem` dirs)
-        then threadWaitWrite socket
-        else threadWaitRead socket
+      case dirs of
+        [] -> pure ()
+        _ ->
+          if (OUTBOUND `elem` dirs)
+            then threadWaitWrite socket
+            else threadWaitRead socket
 
 -- | Sftp
 

--- a/libssh2/src/Network/SSH/Client/LibSSH2/Types.chs
+++ b/libssh2/src/Network/SSH/Client/LibSSH2/Types.chs
@@ -140,6 +140,7 @@ data Direction = INBOUND | OUTBOUND
   deriving (Eq, Show)
 
 int2dir :: (Eq a, Num a, Show a) => a -> [Direction]
+int2dir 0 = []
 int2dir 1 = [INBOUND]
 int2dir 2 = [OUTBOUND]
 int2dir 3 = [INBOUND, OUTBOUND]


### PR DESCRIPTION
A return value of zero for libssh2_session_block_directions means that there is no data waiting to come in or leave. In blocking mode, we don't need to worry about zero, and in nonblocking mode it just means we can make our next call to libssh2.

Fixes #62.