### PR TITLE
sftpWriteFileFromBytes: implement in terms of bytes

### DIFF
--- a/libssh2/src/Network/SSH/Client/LibSSH2/Foreign.chs
+++ b/libssh2/src/Network/SSH/Client/LibSSH2/Foreign.chs
@@ -780,12 +780,12 @@ sftpWriteFileFromBytes sftph bs = BSS.useAsCStringLen bs (uncurry (send 0))
     send :: Int -> Ptr CChar -> Int -> IO Integer
     send written _ 0 = pure (toInteger written)
     send written src len = do
-      let nElements = min len (bufferSize `div` sizeOf (undefined :: CChar))
-      sent <- handleInt (Just sftph)
+      let nBytes = min len bufferSize
+      sent <- fmap fromIntegral . handleInt (Just sftph)
                            $ {# call sftp_write #} (toPointer sftph)
                                                    src
-                                                   (fromIntegral nElements)
-      send (written + fromIntegral sent) (advancePtr src written) (len - fromIntegral sent)
+                                                   (fromIntegral nBytes)
+      send (written + sent) (src `plusPtr` written) (len - sent)
 
     bufferSize :: Int
     bufferSize = 0x100000


### PR DESCRIPTION
Previously we were mixing operations on elements (`advancePtr`) with operations defined on bytes (`CStringLen`, `libss2_sftp_write`).

`plusPtr` is implemented in terms of bytes. This also simplifies the computation of `nElements`, and removes some potentially platform-specific code.