### PR TITLE
Reimplement bindings for session_hostkey and knownhost_checkp

### DIFF
--- a/libssh2/src/Network/SSH/Client/LibSSH2.hs
+++ b/libssh2/src/Network/SSH/Client/LibSSH2.hs
@@ -152,8 +152,8 @@ checkHost :: Session
 checkHost s host port path = do
   kh <- initKnownHosts s
   _numKnownHosts <- knownHostsReadFile kh path
-  (hostkey, _keylen, _keytype) <- getHostKey s
-  result <- checkKnownHost kh host port hostkey [TYPE_PLAIN, KEYENC_RAW]
+  (hostkey, _keytype) <- getHostKey s
+  result <- checkKnownHost kh host port hostkey [TYPE_PLAIN, KEYENC_RAW, KEY_RSA1, KEY_SSHRSA, KEY_SSHDSS]
   freeKnownHosts kh
   return result
 


### PR DESCRIPTION
refs #66

Although this is a bug fix, this changes Haskell type signatures of
exported functions.