### PR TITLE
Windows fix for session_handshake

### DIFF
--- a/libssh2/libssh2.cabal
+++ b/libssh2/libssh2.cabal
@@ -59,12 +59,17 @@ Library
 
   Include-dirs:        include
   Includes:            include/libssh2_local.h
-
+  if os(mingw32) && arch(x86_64)
+    cpp-options: -Dx86_64_HOST_ARCH
+  
+  -- Everything else is some form of Unix
+  if !os(mingw32)
+    build-depends: unix
+  
   Build-depends:       base >= 4 && < 5,
                        network >= 2.3 && < 3.2,
                        syb >= 0.3.3, time >= 1.2,
-                       bytestring >= 0.9,
-                       unix
+                       bytestring >= 0.9
 
   Extra-libraries:     "ssh2"
   pkgconfig-depends:   libssh2 >= 1.2.8


### PR DESCRIPTION
Fix for session_handshake on Windows. The "if windows, if x64, unsigned 64 bit, else unsigned 32 bit, else signed 32 bit" logic was being repeated in a few places (and I had to add it to another place) so I decided to move it into an alias. c2hs does not know the alias can be converted to what it aliases to, so specifying the id function as a marshaller works (since Haskell knows how to unalias).
I was able to list a directory on my machine using login/password authentication and sftp, which probably means it is all working fine.