### PR TITLE
Fix sftp write from bytes ptr math

### DIFF
--- a/libssh2/src/Network/SSH/Client/LibSSH2/Foreign.chs
+++ b/libssh2/src/Network/SSH/Client/LibSSH2/Foreign.chs
@@ -846,7 +846,7 @@ sftpWriteFileFromBytes sftph bs = BSS.useAsCStringLen bs (uncurry (send 0))
                            $ {# call sftp_write #} (toPointer sftph)
                                                    src
                                                    (fromIntegral nBytes)
-      send (written + sent) (src `plusPtr` written) (len - sent)
+      send (written + sent) (src `plusPtr` sent) (len - sent)
 
     bufferSize :: Int
     bufferSize = 0x100000


### PR DESCRIPTION
We're seeing a segfault while using `sftpWriteFileFromBytes` that I believe I've tracked down to the pointer math below.

It appears when sending Bytestrings over  0x10000000 bytes long (~1MB) the implementation does some internal chunking. This appears to have been modeled after the byte chunking used above in `sftpWriteFileFromHandler` but there is a subtle difference.

[`sftpWriteFileFromHandler`](https://github.com/portnov/libssh2-hs/compare/master...MercuryTechnologies:libssh2-hs:fix-sftp-write-from-bytes-ptr-math?expand=1#diff-5ba3dfd6ba24610edfa711aec3c967f657af1b2204efcfe3d2d4549bc5db5cd2R827) moves the pointer up by the amount of bytes written by _prior_ calls, but it passes this as the buffer offset to _this_ call into the FFI.

[`sftpWriteFileFromBytes`](https://github.com/portnov/libssh2-hs/compare/master...MercuryTechnologies:libssh2-hs:fix-sftp-write-from-bytes-ptr-math?expand=1#diff-5ba3dfd6ba24610edfa711aec3c967f657af1b2204efcfe3d2d4549bc5db5cd2L849) does the same pointer math, but instead of passing this buffer to _this_ call, it passes it to the _next_ call into the FFI. Thinking through the first recursion, this would offset the second "write" by 0 which is incorrect. I don't know enough about the underlying library to understand why this is a segfault, but at the very least it I think it's logically incorrect.

To make the `sftpWriteFileFromBytes` internally consistent I've changed this so it moves the pointer by the amount that was sent, in line with the bindings `written` (aggregate bytes sent by all recursive calls to send) and `len` (remaining bytes after scanning the pointer forward).

I can also confirm when we moved our implementation to `sftpWriteFileFromBytes` our segfault went away and uploads worked as expected.
